### PR TITLE
[FEAT] 자동로그인시 메인페이지 닉네임 콜 추가

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="DailyCS">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">

--- a/app/src/main/java/com/example/firebaseexample/MainActivity.kt
+++ b/app/src/main/java/com/example/firebaseexample/MainActivity.kt
@@ -83,6 +83,7 @@ class MainActivity : ComponentActivity() {
                             goToQuizListPage = { navController.navigate("quizList") },
                             goToTodayQuizPage = { navController.navigate("todayQuiz") },
                             goToBrushQuizPage = { navController.navigate("brushupQuiz")},
+                            goToNicknamePage = { navController.navigate("nickname") }
                         )
                     }
 

--- a/app/src/main/java/com/example/firebaseexample/ui/pages/MainPage.kt
+++ b/app/src/main/java/com/example/firebaseexample/ui/pages/MainPage.kt
@@ -52,7 +52,8 @@ fun MainPage(
     onLogout: () -> Unit,
     goToQuizListPage: () -> Unit,
     goToTodayQuizPage: () -> Unit, // 오늘의 퀴즈 페이지로 이동하는 콜백
-    goToBrushQuizPage: () -> Unit // 복습 추천 문제 페이지로 이동하는 콜백
+    goToBrushQuizPage: () -> Unit, // 복습 추천 문제 페이지로 이동하는 콜백
+    goToNicknamePage: () -> Unit // 닉네임 페이지로 이동하는 콜백
 ) {
     var showDialog by remember { mutableStateOf(false) } // 팝업창 상태 관리
     val quizRepository = QuizRepository()
@@ -71,8 +72,9 @@ fun MainPage(
                 title = {
                     nickname?.let {
                         Text(
-                            text = it, // 닉네임 출력
-                            style = Typography.titleLarge
+                            text = it,
+                            style = Typography.titleLarge,
+                            modifier = Modifier.clickable { goToNicknamePage() } // 클릭 시 닉네임 페이지로 이동
                         )
                     }
                 },

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Fri Dec 06 22:30:03 KST 2024
-sdk.dir=C\:\\Users\\yjshd\\AppData\\Local\\Android\\Sdk
+#Mon Dec 09 17:39:34 KST 2024
+sdk.dir=/Users/klee/Library/Android/sdk


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- 자동로그인 시 메인 페이지에서 닉네임 호출이 안되던 버그를 고쳤습니다.

## 🔍 작업 상세 (Implementation Details)
- 로그인 정보가 남아서 자동 로그인될 때 닉네임뷰모델을 업데이트하는 로직이 없어 닉네임을 못 불러오던 버그
- 메인 페이지가 콜 될 때, LaunchedEffect 부분에 사용자 정보(userId)로 닉네임을 호출하는 함수를 추가했습니다.